### PR TITLE
fix: update NoPreprocessorGuard to restrict #define usage in formulas

### DIFF
--- a/src/compiler/NoPreprocessorGuard.hpp
+++ b/src/compiler/NoPreprocessorGuard.hpp
@@ -17,14 +17,14 @@ namespace formula::compiler {
      */
     class NoPreprocessorGuard : public SecurityGuard {
     public:
-        NoPreprocessorGuard() : noPreprocessorRegex(R"(^\s*#.*)") { }
+        NoPreprocessorGuard() : noPreprocessorRegex(R"(^\s*#include\b)") { }
 
         bool checkLine(std::string& line) override {
             auto found = std::regex_search(line, noPreprocessorRegex);
             if (found) {
                 setErrorMessage(
                     line + "\r\n" +
-                    "\tPreprocessor definitions (#include, #define, ...) are not allowed in formulas for safety reasons."
+                    "\t#include is not allowed in formulas for safety reasons."
                 );
             }
             return found;


### PR DESCRIPTION
I've modified the NoPreprocessorGuard regex to only filter out #include directives.

This should allow #define statements which are not a known vector for attacks.